### PR TITLE
Leveraging embedding to make code more readable

### DIFF
--- a/authapi/authapi.go
+++ b/authapi/authapi.go
@@ -9,14 +9,14 @@ import (
 )
 
 type AuthApi struct {
-	api duoapi.DuoApi
+	duoapi.DuoApi
 }
 
 // Build a new Duo Auth API object.
 // api is a duoapi.DuoApi object used to make the Duo Rest API calls.
 // Example: authapi.NewAuthApi(*duoapi.NewDuoApi(ikey,skey,host,userAgent,duoapi.SetTimeout(10*time.Second)))
 func NewAuthApi(api duoapi.DuoApi) *AuthApi {
-	return &AuthApi{api: api}
+	return &AuthApi{api}
 }
 
 // API calls will return a StatResult object.  On success, Stat is 'OK'.
@@ -41,7 +41,7 @@ type PingResult struct {
 // This is an unsigned Duo Rest API call which returns the Duo system's time.
 // Use this method to determine whether your system time is in sync with Duo's.
 func (api *AuthApi) Ping() (*PingResult, error) {
-	_, body, err := api.api.Call("GET", "/auth/v2/ping", nil, duoapi.UseTimeout)
+	_, body, err := api.Call("GET", "/auth/v2/ping", nil, duoapi.UseTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ type CheckResult struct {
 // Use this method to determine whether your ikey, skey and host are correct,
 // and whether your system time is in sync with Duo's.
 func (api *AuthApi) Check() (*CheckResult, error) {
-	_, body, err := api.api.SignedCall("GET", "/auth/v2/check", nil, duoapi.UseTimeout)
+	_, body, err := api.SignedCall("GET", "/auth/v2/check", nil, duoapi.UseTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ type LogoResult struct {
 // If the API call is successful, the configured logo png is returned.  Othwerwise,
 // error information is returned in the LogoResult return value.
 func (api *AuthApi) Logo() (*LogoResult, error) {
-	resp, body, err := api.api.SignedCall("GET", "/auth/v2/logo", nil, duoapi.UseTimeout)
+	resp, body, err := api.SignedCall("GET", "/auth/v2/logo", nil, duoapi.UseTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +138,7 @@ func (api *AuthApi) Enroll(options ...func(*url.Values)) (*EnrollResult, error) 
 		o(&opts)
 	}
 
-	_, body, err := api.api.SignedCall("POST", "/auth/v2/enroll", opts, duoapi.UseTimeout)
+	_, body, err := api.SignedCall("POST", "/auth/v2/enroll", opts, duoapi.UseTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (api *AuthApi) EnrollStatus(userid string,
 	queryArgs.Set("user_id", userid)
 	queryArgs.Set("activation_code", activationCode)
 
-	_, body, err := api.api.SignedCall("POST",
+	_, body, err := api.SignedCall("POST",
 		"/auth/v2/enroll_status",
 		queryArgs,
 		duoapi.UseTimeout)
@@ -232,7 +232,7 @@ func (api *AuthApi) Preauth(options ...func(*url.Values)) (*PreauthResult, error
 	for _, o := range options {
 		o(&opts)
 	}
-	_, body, err := api.api.SignedCall("POST", "/auth/v2/preauth", opts, duoapi.UseTimeout)
+	_, body, err := api.SignedCall("POST", "/auth/v2/preauth", opts, duoapi.UseTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +340,7 @@ func (api *AuthApi) Auth(factor string, options ...func(*url.Values)) (*AuthResu
 		apiOps = append(apiOps, duoapi.UseTimeout)
 	}
 
-	_, body, err := api.api.SignedCall("POST", "/auth/v2/auth", params, apiOps...)
+	_, body, err := api.SignedCall("POST", "/auth/v2/auth", params, apiOps...)
 	if err != nil {
 		return nil, err
 	}
@@ -369,7 +369,7 @@ type AuthStatusResult struct {
 func (api *AuthApi) AuthStatus(txid string) (*AuthStatusResult, error) {
 	opts := url.Values{}
 	opts.Set("txid", txid)
-	_, body, err := api.api.SignedCall("GET", "/auth/v2/auth_status", opts)
+	_, body, err := api.SignedCall("GET", "/auth/v2/auth_status", opts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A slick feature of Go is the ability to use [embedding](https://golang.org/doc/effective_go.html#embedding). This is roughly comparable to subclassing.

Since ```authapi.AuthApi``` needs all the same functions supplied by ```duoapi.DuoApi```, we can just embed an instance of ```duoapi.DuoApi``` in our ```AuthApi```. So now, instead of calling ```api.api.Something()```, we can just call ```api.Something()```.

After these changes, the code is more readable, we don't break backwards compatibility, and the tests still pass just fine:

```
C:\go\src\github.com\duosecurity\duo_api_golang>go test -v ./...
=== RUN   TestCanonicalize
--- PASS: TestCanonicalize (0.00s)
=== RUN   TestSimple
--- PASS: TestSimple (0.00s)
=== RUN   TestZero
--- PASS: TestZero (0.00s)
=== RUN   TestOne
--- PASS: TestOne (0.00s)
=== RUN   TestPrintableAsciiCharaceters
--- PASS: TestPrintableAsciiCharaceters (0.00s)
=== RUN   TestSortOrderWithCommonPrefix
--- PASS: TestSortOrderWithCommonPrefix (0.00s)
=== RUN   TestUnicodeFuzzValues
--- PASS: TestUnicodeFuzzValues (0.00s)
=== RUN   TestUnicodeFuzzKeysAndValues
--- PASS: TestUnicodeFuzzKeysAndValues (0.00s)
=== RUN   TestSign
--- PASS: TestSign (0.00s)
=== RUN   TestV2Canonicalize
--- PASS: TestV2Canonicalize (0.00s)
=== RUN   TestNewDuo
--- PASS: TestNewDuo (0.00s)
PASS
ok      github.com/duosecurity/duo_api_golang   0.081s
=== RUN   TestTimeout
--- PASS: TestTimeout (1.00s)
=== RUN   TestPing
--- PASS: TestPing (0.02s)
=== RUN   TestCheck
--- PASS: TestCheck (0.02s)
=== RUN   TestLogo
--- PASS: TestLogo (0.02s)
=== RUN   TestLogoError
--- PASS: TestLogoError (0.02s)
=== RUN   TestEnroll
--- PASS: TestEnroll (0.02s)
=== RUN   TestEnrollStatus
--- PASS: TestEnrollStatus (0.02s)
=== RUN   TestPreauthUserId
--- PASS: TestPreauthUserId (0.02s)
=== RUN   TestPreauthEnroll
--- PASS: TestPreauthEnroll (0.02s)
=== RUN   TestAuth
--- PASS: TestAuth (0.02s)
=== RUN   TestAuthStatus
--- PASS: TestAuthStatus (0.02s)
PASS
ok      github.com/duosecurity/duo_api_golang/authapi   1.264s
```