### PR TITLE
Allow Duo to use HTTP proxy via default Go proxy resolution logic

### DIFF
--- a/duoapi.go
+++ b/duoapi.go
@@ -112,8 +112,8 @@ func NewDuoApi(ikey string,
 	certPool.AppendCertsFromPEM([]byte(duoPinnedCert))
 
 	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
-			Proxy: ProxyFromEnvironment,
 			RootCAs:            certPool,
 			InsecureSkipVerify: opts.insecure,
 		},

--- a/duoapi.go
+++ b/duoapi.go
@@ -113,6 +113,7 @@ func NewDuoApi(ikey string,
 
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
+			Proxy: ProxyFromEnvironment,
 			RootCAs:            certPool,
 			InsecureSkipVerify: opts.insecure,
 		},


### PR DESCRIPTION
The default Go HTTP transport (https://golang.org/src/net/http/transport.go - var DefaultTransport) uses the ProxyFromEnvironment setting to read whether an HTTP or HTTPS proxy has been set. If a transport is defined without Proxy being set, the behavior defaults to not using a proxy regardless of what environment variables are in place (line 79 from transport.go - "If Proxy is nil or returns a nil *URL, no proxy is used").

The impact: Because Duo sets a custom HTTP transport for certificate pinning, it is **impossible** to use the Go API implementation behind a proxy unless proxy logic is added to the transport. This impacts the Hashicorp Vault MFA backend for Duo, which consumes this API. It's also going to be a barrier to enterprise use or for any other customer which restricts direct access to the Internet outbound from servers.

This PR is a simple fix to add the standard Go proxy resolution logic to the Duo HTTP transport.