### PR TITLE
Fix Go 1.10 test failure.

### DIFF
--- a/authapi/authapi_test.go
+++ b/authapi/authapi_test.go
@@ -52,7 +52,7 @@ func TestTimeout(t *testing.T) {
 	_, err := duo.Ping()
 	duration := time.Since(start)
 	if duration.Seconds() > 2 {
-		t.Error("Timeout took %d seconds", duration.Seconds())
+		t.Errorf("Timeout took %v seconds", duration.Seconds())
 	}
 	if err == nil {
 		t.Error("Expected timeout error.")


### PR DESCRIPTION
I maintain the Fedora package of duo_api_golang, and the recent update to go 1.10 (slated to appear in Fedora 28) triggered a test failure due to `go vet` being [run by default now](https://golang.org/doc/go1.10#test). This patch cleans up the issue and allows tests to pass again.