### PR TITLE
Fix GetUser response unmarshalling 

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -135,6 +135,12 @@ type GetUsersResult struct {
 	Response []User
 }
 
+// GetUserResult models responses containing a single user.
+type GetUserResult struct {
+	duoapi.StatResult
+	Response User
+}
+
 func (result *GetUsersResult) getResponse() interface{} {
 	return result.Response
 }
@@ -188,7 +194,7 @@ func (c *Client) retrieveItems(
 		}
 
 		params.Set("offset", accumulator.metadata().NextOffset.String())
-		for ; params.Get("offset") != "" ; {
+		for params.Get("offset") != "" {
 			nextResult, err := fetcher(params)
 			if err != nil {
 				return nil, err
@@ -219,7 +225,7 @@ func (c *Client) retrieveUsers(params url.Values) (*GetUsersResult, error) {
 
 // GetUser calls GET /admin/v1/users/:user_id
 // See https://duo.com/docs/adminapi#retrieve-user-by-id
-func (c *Client) GetUser(userID string) (*GetUsersResult, error) {
+func (c *Client) GetUser(userID string) (*GetUserResult, error) {
 	path := fmt.Sprintf("/admin/v1/users/%s", userID)
 
 	_, body, err := c.SignedCall(http.MethodGet, path, nil, duoapi.UseTimeout)
@@ -227,7 +233,7 @@ func (c *Client) GetUser(userID string) (*GetUsersResult, error) {
 		return nil, err
 	}
 
-	result := &GetUsersResult{}
+	result := &GetUserResult{}
 	err = json.Unmarshal(body, result)
 	if err != nil {
 		return nil, err
@@ -509,7 +515,6 @@ func (result *GetPhonesResult) appendResponse(phones interface{}) {
 	result.Response = append(result.Response, asserted_phones...)
 }
 
-
 // GetPhones calls GET /admin/v1/phones
 // See https://duo.com/docs/adminapi#phones
 func (c *Client) GetPhones(options ...func(*url.Values)) (*GetPhonesResult, error) {
@@ -593,7 +598,6 @@ func (result *GetTokensResult) appendResponse(tokens interface{}) {
 	result.Response = append(result.Response, asserted_tokens...)
 }
 
-
 // GetTokens calls GET /admin/v1/tokens
 // See https://duo.com/docs/adminapi#retrieve-hardware-tokens
 func (c *Client) GetTokens(options ...func(*url.Values)) (*GetTokensResult, error) {
@@ -668,7 +672,6 @@ func (result *GetU2FTokensResult) appendResponse(tokens interface{}) {
 	asserted_tokens := tokens.([]U2FToken)
 	result.Response = append(result.Response, asserted_tokens...)
 }
-
 
 // GetU2FTokens calls GET /admin/v1/u2ftokens
 // See https://duo.com/docs/adminapi#retrieve-u2f-tokens

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -84,6 +84,53 @@ const getUsersResponse = `{
 	}]
 }`
 
+const getUserResponse = `{
+	"stat": "OK",
+	"response": {
+		"alias1": "joe.smith",
+		"alias2": "jsmith@example.com",
+		"alias3": null,
+		"alias4": null,
+		"created": 1489612729,
+		"email": "jsmith@example.com",
+		"firstname": "Joe",
+		"groups": [{
+			"desc": "People with hardware tokens",
+			"name": "token_users"
+		}],
+		"last_directory_sync": 1508789163,
+		"last_login": 1343921403,
+		"lastname": "Smith",
+		"notes": "",
+		"phones": [{
+			"phone_id": "DPFZRS9FB0D46QFTM899",
+			"number": "+15555550100",
+			"extension": "",
+			"name": "",
+			"postdelay": null,
+			"predelay": null,
+			"type": "Mobile",
+			"capabilities": [
+				"sms",
+				"phone",
+				"push"
+			],
+			"platform": "Apple iOS",
+			"activated": false,
+			"sms_passcodes_sent": false
+		}],
+		"realname": "Joe Smith",
+		"status": "active",
+		"tokens": [{
+			"serial": "0",
+			"token_id": "DHIZ34ALBA2445ND4AI2",
+			"type": "d1"
+		}],
+		"user_id": "DU3RP9I2WOC59VZX672N",
+		"username": "jsmith"
+	}
+}`
+
 func TestGetUsers(t *testing.T) {
 	var last_request *http.Request
 	ts := httptest.NewTLSServer(
@@ -281,7 +328,7 @@ func TestGetUserPageArgs(t *testing.T) {
 
 	duo := buildAdminClient(ts.URL, nil)
 
-	_, err := duo.GetUsers(func(values *url.Values){
+	_, err := duo.GetUsers(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
 		return
@@ -307,7 +354,7 @@ func TestGetUserPageArgs(t *testing.T) {
 func TestGetUser(t *testing.T) {
 	ts := httptest.NewTLSServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintln(w, getUsersResponse)
+			fmt.Fprintln(w, getUserResponse)
 		}),
 	)
 	defer ts.Close()
@@ -321,11 +368,8 @@ func TestGetUser(t *testing.T) {
 	if result.Stat != "OK" {
 		t.Errorf("Expected OK, but got %s", result.Stat)
 	}
-	if len(result.Response) != 1 {
-		t.Errorf("Expected 1 user, but got %d", len(result.Response))
-	}
-	if result.Response[0].UserID != "DU3RP9I2WOC59VZX672N" {
-		t.Errorf("Expected user ID DU3RP9I2WOC59VZX672N, but got %s", result.Response[0].UserID)
+	if result.Response.UserID != "DU3RP9I2WOC59VZX672N" {
+		t.Errorf("Expected user ID DU3RP9I2WOC59VZX672N, but got %s", result.Response.UserID)
 	}
 }
 
@@ -495,7 +539,7 @@ func TestGetUserGroupsPageArgs(t *testing.T) {
 
 	duo := buildAdminClient(ts.URL, nil)
 
-	_, err := duo.GetUserGroups("DU3RP9I2WOC59VZX672N", func(values *url.Values){
+	_, err := duo.GetUserGroups("DU3RP9I2WOC59VZX672N", func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
 		return
@@ -720,7 +764,7 @@ func TestGetUserPhonesPageArgs(t *testing.T) {
 
 	duo := buildAdminClient(ts.URL, nil)
 
-	_, err := duo.GetUserPhones("DU3RP9I2WOC59VZX672N", func(values *url.Values){
+	_, err := duo.GetUserPhones("DU3RP9I2WOC59VZX672N", func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
 		return
@@ -882,7 +926,7 @@ func TestGetUserTokensPageArgs(t *testing.T) {
 
 	duo := buildAdminClient(ts.URL, nil)
 
-	_, err := duo.GetUserTokens("DU3RP9I2WOC59VZX672N", func(values *url.Values){
+	_, err := duo.GetUserTokens("DU3RP9I2WOC59VZX672N", func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
 		return
@@ -1050,7 +1094,7 @@ func TestGetUserU2FTokensPageArgs(t *testing.T) {
 
 	duo := buildAdminClient(ts.URL, nil)
 
-	_, err := duo.GetUserU2FTokens("DU3RP9I2WOC59VZX672N", func(values *url.Values){
+	_, err := duo.GetUserU2FTokens("DU3RP9I2WOC59VZX672N", func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
 		return
@@ -1152,7 +1196,7 @@ func TestGetGroupsPageArgs(t *testing.T) {
 
 	duo := buildAdminClient(ts.URL, nil)
 
-	_, err := duo.GetGroups(func(values *url.Values){
+	_, err := duo.GetGroups(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
 		return
@@ -1431,7 +1475,7 @@ func TestGetPhonesPageArgs(t *testing.T) {
 
 	duo := buildAdminClient(ts.URL, nil)
 
-	_, err := duo.GetPhones(func(values *url.Values){
+	_, err := duo.GetPhones(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
 		return
@@ -1665,7 +1709,7 @@ func TestGetTokensPageArgs(t *testing.T) {
 
 	duo := buildAdminClient(ts.URL, nil)
 
-	_, err := duo.GetTokens(func(values *url.Values){
+	_, err := duo.GetTokens(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
 		return
@@ -1900,7 +1944,7 @@ func TestGetU2FTokensPageArgs(t *testing.T) {
 
 	duo := buildAdminClient(ts.URL, nil)
 
-	_, err := duo.GetU2FTokens(func(values *url.Values){
+	_, err := duo.GetU2FTokens(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
 		return


### PR DESCRIPTION
It appears that when retrieving a single user via the API, the response is now a single user object instead of a user object list with a length of 1.  This fixes the `GetUser` function so that it can properly unmarshal a single user response. 