### PR TITLE
Change Pointer Data Types in admin.User to Built-in Data Types, Various Linting Fixes

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/duosecurity/duo_api_golang"
+	duoapi "github.com/duosecurity/duo_api_golang"
 )
 
 // Client provides access to Duo's admin API.
@@ -36,20 +36,20 @@ func New(base duoapi.DuoApi) *Client {
 
 // User models a single user.
 type User struct {
-	Alias1            *string
-	Alias2            *string
-	Alias3            *string
-	Alias4            *string
+	Alias1            string
+	Alias2            string
+	Alias3            string
+	Alias4            string
 	Created           uint64
 	Email             string
-	FirstName         *string
+	FirstName         string
 	Groups            []Group
-	LastDirectorySync *uint64 `json:"last_directory_sync"`
-	LastLogin         *uint64 `json:"last_login"`
-	LastName          *string
+	LastDirectorySync uint64 `json:"last_directory_sync"`
+	LastLogin         uint64 `json:"last_login"`
+	LastName          string
 	Notes             string
 	Phones            []Phone
-	RealName          *string
+	RealName          string
 	Status            string
 	Tokens            []Token
 	UserID            string `json:"user_id"`

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -10,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/duosecurity/duo_api_golang"
+	duoapi "github.com/duosecurity/duo_api_golang"
 )
 
 func buildAdminClient(url string, proxy func(*http.Request) (*url.URL, error)) *Client {
@@ -20,16 +19,6 @@ func buildAdminClient(url string, proxy func(*http.Request) (*url.URL, error)) *
 	userAgent := "GoTestClient"
 	base := duoapi.NewDuoApi(ikey, skey, host, userAgent, duoapi.SetTimeout(1*time.Second), duoapi.SetInsecure(), duoapi.SetProxy(proxy))
 	return New(*base)
-}
-
-func getBodyParams(r *http.Request) (url.Values, error) {
-	body, err := ioutil.ReadAll(r.Body)
-	r.Body.Close()
-	if err != nil {
-		return url.Values{}, err
-	}
-	reqParams, err := url.ParseQuery(string(body))
-	return reqParams, err
 }
 
 const getUsersResponse = `{
@@ -331,7 +320,6 @@ func TestGetUserPageArgs(t *testing.T) {
 	_, err := duo.GetUsers(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
-		return
 	})
 
 	if err != nil {
@@ -542,7 +530,6 @@ func TestGetUserGroupsPageArgs(t *testing.T) {
 	_, err := duo.GetUserGroups("DU3RP9I2WOC59VZX672N", func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
-		return
 	})
 
 	if err != nil {
@@ -767,7 +754,6 @@ func TestGetUserPhonesPageArgs(t *testing.T) {
 	_, err := duo.GetUserPhones("DU3RP9I2WOC59VZX672N", func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
-		return
 	})
 
 	if err != nil {
@@ -929,7 +915,6 @@ func TestGetUserTokensPageArgs(t *testing.T) {
 	_, err := duo.GetUserTokens("DU3RP9I2WOC59VZX672N", func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
-		return
 	})
 
 	if err != nil {
@@ -1097,7 +1082,6 @@ func TestGetUserU2FTokensPageArgs(t *testing.T) {
 	_, err := duo.GetUserU2FTokens("DU3RP9I2WOC59VZX672N", func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
-		return
 	})
 
 	if err != nil {
@@ -1199,7 +1183,6 @@ func TestGetGroupsPageArgs(t *testing.T) {
 	_, err := duo.GetGroups(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
-		return
 	})
 
 	if err != nil {
@@ -1478,7 +1461,6 @@ func TestGetPhonesPageArgs(t *testing.T) {
 	_, err := duo.GetPhones(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
-		return
 	})
 
 	if err != nil {
@@ -1712,7 +1694,6 @@ func TestGetTokensPageArgs(t *testing.T) {
 	_, err := duo.GetTokens(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
-		return
 	})
 
 	if err != nil {
@@ -1947,7 +1928,6 @@ func TestGetU2FTokensPageArgs(t *testing.T) {
 	_, err := duo.GetU2FTokens(func(values *url.Values) {
 		values.Set("limit", "200")
 		values.Set("offset", "1")
-		return
 	})
 
 	if err != nil {

--- a/authapi/authapi.go
+++ b/authapi/authapi.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 	"strconv"
 
-	"github.com/duosecurity/duo_api_golang"
+	duoapi "github.com/duosecurity/duo_api_golang"
 )
 
 type AuthApi struct {
@@ -336,7 +336,7 @@ func (api *AuthApi) Auth(factor string, options ...func(*url.Values)) (*AuthResu
 	params.Set("factor", factor)
 
 	var apiOps []duoapi.DuoApiOption
-	if _, ok := params["async"]; ok == true {
+	if _, ok := params["async"]; ok {
 		apiOps = append(apiOps, duoapi.UseTimeout)
 	}
 

--- a/duoapi.go
+++ b/duoapi.go
@@ -52,7 +52,7 @@ func sign(ikey string,
 	params url.Values) string {
 	canon := canonicalize(method, host, uri, params, date)
 	mac := hmac.New(sha1.New, []byte(skey))
-	mac.Write([]byte(canon))
+	_, _ = mac.Write([]byte(canon))
 	sig := hex.EncodeToString(mac.Sum(nil))
 	auth := ikey + ":" + sig
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
@@ -77,7 +77,6 @@ type apiOptions struct {
 func SetTimeout(timeout time.Duration) func(*apiOptions) {
 	return func(opts *apiOptions) {
 		opts.timeout = timeout
-		return
 	}
 }
 


### PR DESCRIPTION
- admin.go: Change all attribute types with pointers to their basic data
types. In general, built-in type values should be shared by copying not
pointers [1].
- admin.go: Reorder admin.Group and admin.Phone structs to save a few
bytes of memory.
- admin_test.go: getBodyParams is unused, so deleted due to deadcode.
- admin_test.go: Removed redundant returns.
- authapi.go: "ok == true" can be expressed as "ok" in a conditional.
- authapi_test.go: Check error returns, or explicitly ignore them as appropriate.
- authapi_test.go: Removed redundant return.

[1] - https://www.ardanlabs.com/blog/2014/12/using-pointers-in-go.html
Signed-off-by: Benjamin S. Allen <bsallen@alcf.anl.gov>