### PR TITLE
Added SetTransport option

### DIFF
--- a/duo_test.go
+++ b/duo_test.go
@@ -161,6 +161,20 @@ func TestNewDuo(t *testing.T) {
 	}
 }
 
+func TestSetTransport(t *testing.T) {
+	transportOpt := func(tr *http.Transport) {
+		tr.MaxResponseHeaderBytes = 12345
+	}
+
+	duo := NewDuoApi("ABC", "123", "api-XXXXXXX.duosecurity.com", "go-client", SetTransport(transportOpt))
+
+	httpClient := duo.apiClient.(*http.Client)
+	transport := httpClient.Transport.(*http.Transport)
+	if transport.MaxResponseHeaderBytes != 12345 {
+		t.Fatal("SetTransport failed to update Duo HTTP client transport configuration")
+	}
+}
+
 func TestDupApiCallHttpErr(t *testing.T) {
 	httpClient := &mockHttpClient{doError: true}
 	sleepSvc := &mockSleepService{}

--- a/duoapi.go
+++ b/duoapi.go
@@ -90,9 +90,10 @@ func (svc timeSleepService) Sleep(duration time.Duration) {
 }
 
 type apiOptions struct {
-	timeout  time.Duration
-	insecure bool
-	proxy    func(*http.Request) (*url.URL, error)
+	timeout   time.Duration
+	insecure  bool
+	proxy     func(*http.Request) (*url.URL, error)
+	transport func(*http.Transport)
 }
 
 // Optional parameter for NewDuoApi, used to configure timeouts on API calls.
@@ -115,6 +116,13 @@ func SetInsecure() func(*apiOptions) {
 func SetProxy(proxy func(*http.Request) (*url.URL, error)) func(*apiOptions) {
 	return func(opts *apiOptions) {
 		opts.proxy = proxy
+	}
+}
+
+// SetTransport enables additional control over the HTTP transport used to connect to the Duo API.
+func SetTransport(transport func(*http.Transport)) func(*apiOptions) {
+	return func(opts *apiOptions) {
+		opts.transport = transport
 	}
 }
 
@@ -149,6 +157,10 @@ func NewDuoApi(ikey string,
 			InsecureSkipVerify: opts.insecure,
 		},
 	}
+	if opts.transport != nil {
+		opts.transport(tr)
+	}
+
 	return &DuoApi{
 		ikey:      ikey,
 		skey:      skey,


### PR DESCRIPTION
# Summary
The `SetTransport` option provides users with additional control over the `*http.Transport` used to communicate with the Duo API. This enables capabilities such as configuring a TLS client certificate for HTTPS proxies.

# Test Plan
This change adds a simple `TestSetTransport` test case to ensure that when the option is provided, the utilized `*http.Transport` is updated accordingly.
```
go fmt ./...

go vet ./...

go test ./...
ok      github.com/duosecurity/duo_api_golang   0.178s
ok      github.com/duosecurity/duo_api_golang/admin     0.475s
ok      github.com/duosecurity/duo_api_golang/authapi   1.317s
```