### PR TITLE
Add functions for Create/Modify/Delete User, Associate/Disassociate Group, and User to url.Values

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -37,20 +37,20 @@ func New(base duoapi.DuoApi) *Client {
 
 // User models a single user.
 type User struct {
-	Alias1            *string `url:"alias1"`
-	Alias2            *string `url:"alias2"`
-	Alias3            *string `url:"alias3"`
-	Alias4            *string `url:"alias4"`
+	Alias1            *string `url:"alias1,omitempty"`
+	Alias2            *string `url:"alias2,omitempty"`
+	Alias3            *string `url:"alias3,omitempty"`
+	Alias4            *string `url:"alias4,omitempty"`
 	Created           uint64  `url:"created"`
 	Email             string  `url:"email"`
-	FirstName         *string `url:"firstname"`
+	FirstName         *string `url:"firstname,omitempty"`
 	Groups            []Group
 	LastDirectorySync *uint64 `json:"last_directory_sync"`
 	LastLogin         *uint64 `json:"last_login"`
-	LastName          *string `url:"lastname"`
-	Notes             string  `url:"notes"`
+	LastName          *string `url:"lastname,omitempty"`
+	Notes             string  `url:"notes,omitempty"`
 	Phones            []Phone
-	RealName          *string `url:"realname"`
+	RealName          *string `url:"realname,omitempty"`
 	Status            string  `url:"status"`
 	Tokens            []Token
 	UserID            string `json:"user_id"`

--- a/admin/admin.go
+++ b/admin/admin.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	duoapi "github.com/duosecurity/duo_api_golang"
+	"github.com/google/go-querystring/query"
 )
 
 // Client provides access to Duo's admin API.
@@ -36,24 +37,24 @@ func New(base duoapi.DuoApi) *Client {
 
 // User models a single user.
 type User struct {
-	Alias1            *string
-	Alias2            *string
-	Alias3            *string
-	Alias4            *string
-	Created           uint64
-	Email             string
-	FirstName         *string
+	Alias1            *string `url:"alias1"`
+	Alias2            *string `url:"alias2"`
+	Alias3            *string `url:"alias3"`
+	Alias4            *string `url:"alias4"`
+	Created           uint64  `url:"created"`
+	Email             string  `url:"email"`
+	FirstName         *string `url:"firstname"`
 	Groups            []Group
 	LastDirectorySync *uint64 `json:"last_directory_sync"`
 	LastLogin         *uint64 `json:"last_login"`
-	LastName          *string
-	Notes             string
+	LastName          *string `url:"lastname"`
+	Notes             string  `url:"notes"`
 	Phones            []Phone
-	RealName          *string
-	Status            string
+	RealName          *string `url:"realname"`
+	Status            string  `url:"status"`
 	Tokens            []Token
 	UserID            string `json:"user_id"`
-	Username          string
+	Username          string `url:"username"`
 }
 
 // Group models a group to which users may belong.
@@ -243,6 +244,70 @@ func (c *Client) GetUser(userID string) (*GetUserResult, error) {
 	return result, nil
 }
 
+// CreateUser calls POST /admin/v1/users
+// See https://duo.com/docs/adminapi#create-user
+func (c *Client) CreateUser(userToCreate User) (*GetUserResult, error) {
+	path := "/admin/v1/users"
+
+	params, err := query.Values(userToCreate)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, err := c.SignedCall(http.MethodPost, path, params, duoapi.UseTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &GetUserResult{}
+	err = json.Unmarshal(body, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ModifyUser calls POST /admin/v1/users/:user_id
+// See https://duo.com/docs/adminapi#modify-user
+func (c *Client) ModifyUser(userID string, userToModify User) (*GetUserResult, error) {
+	path := fmt.Sprintf("/admin/v1/users/%s", userID)
+
+	params, err := query.Values(userToModify)
+	if err != nil {
+		return nil, err
+	}
+
+	_, body, err := c.SignedCall(http.MethodPost, path, params, duoapi.UseTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &GetUserResult{}
+	err = json.Unmarshal(body, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DeleteUser calls DELETE /admin/v1/users/:user_id
+// See https://duo.com/docs/adminapi#delete-user
+func (c *Client) DeleteUser(userID string) (*duoapi.StatResult, error) {
+	path := fmt.Sprintf("/admin/v1/users/%s", userID)
+
+	_, body, err := c.SignedCall(http.MethodDelete, path, nil, duoapi.UseTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &duoapi.StatResult{}
+	err = json.Unmarshal(body, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // GetUserGroups calls GET /admin/v1/users/:user_id/groups
 // See https://duo.com/docs/adminapi#retrieve-groups-by-user-id
 func (c *Client) GetUserGroups(userID string, options ...func(*url.Values)) (*GetGroupsResult, error) {
@@ -260,6 +325,45 @@ func (c *Client) GetUserGroups(userID string, options ...func(*url.Values)) (*Ge
 	}
 
 	return response.(*GetGroupsResult), nil
+}
+
+// AssociateGroupWithUser calls POST /admin/v1/users/:user_id/groups
+// See https://duo.com/docs/adminapi#associate-group-with-user
+func (c *Client) AssociateGroupWithUser(userID string, groupID string) (*duoapi.StatResult, error) {
+	path := fmt.Sprintf("/admin/v1/users/%s/groups", userID)
+
+	params := url.Values{}
+	params.Set("group_id", groupID)
+
+	_, body, err := c.SignedCall(http.MethodPost, path, params, duoapi.UseTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &duoapi.StatResult{}
+	err = json.Unmarshal(body, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// DisassociateGroupFromUser calls POST /admin/v1/users/:user_id/groups
+// See https://duo.com/docs/adminapi#disassociate-group-from-user
+func (c *Client) DisassociateGroupFromUser(userID string, groupID string) (*duoapi.StatResult, error) {
+	path := fmt.Sprintf("/admin/v1/users/%s/groups/%s", userID, groupID)
+
+	_, body, err := c.SignedCall(http.MethodDelete, path, nil, duoapi.UseTimeout)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &duoapi.StatResult{}
+	err = json.Unmarshal(body, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func (c *Client) retrieveUserGroups(userID string, params url.Values) (*GetGroupsResult, error) {

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -170,6 +170,162 @@ func TestGetUsers(t *testing.T) {
 	}
 }
 
+const createUserResponse = `{
+	"stat": "OK",
+	"response": {
+		"alias1": null,
+		"alias2": null,
+		"alias3": null,
+		"alias4": null,
+		"created": 1489612729,
+		"email": "jsmith@example.com",
+		"firstname": null,
+		"groups": [],
+		"last_directory_sync": null,
+		"last_login": null,
+		"lastname": null,
+		"notes": "",
+		"phones": [],
+		"realname": null,
+		"status": "active",
+		"tokens": [],
+		"user_id": "DU3RP9I2WOC59VZX672N",
+		"username": "jsmith"
+	}
+}`
+
+func TestCreateUser(t *testing.T) {
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, createUserResponse)
+		}),
+	)
+	defer ts.Close()
+
+	duo := buildAdminClient(ts.URL, nil)
+
+	userToCreate := User{
+		Username: "jsmith",
+		Email:    "jsmith@example.com",
+		Status:   "active",
+	}
+
+	result, err := duo.CreateUser(userToCreate)
+	if err != nil {
+		t.Errorf("Unexpected error from CreateUser call %v", err.Error())
+	}
+	if result.Stat != "OK" {
+		t.Errorf("Expected OK, but got %s", result.Stat)
+	}
+	if result.Response.Username != userToCreate.Username {
+		t.Errorf("Expected Username to be %s, but got %s", userToCreate.Username, result.Response.Username)
+	}
+	if result.Response.Email != userToCreate.Email {
+		t.Errorf("Expected Email to be %s, but got %s", userToCreate.Email, result.Response.Email)
+	}
+}
+
+const modifyUserResponse = `{
+	"stat": "OK",
+	"response": {
+		"alias1": "joe.smith",
+		"alias2": "jsmith@example.com",
+		"alias3": null,
+		"alias4": null,
+		"created": 1489612729,
+		"email": "jsmith-new@example.com",
+		"firstname": "Joe",
+		"groups": [{
+			"desc": "People with hardware tokens",
+			"name": "token_users"
+		}],
+		"last_directory_sync": 1508789163,
+		"last_login": 1343921403,
+		"lastname": "Smith",
+		"notes": "",
+		"phones": [{
+			"phone_id": "DPFZRS9FB0D46QFTM899",
+			"number": "+15555550100",
+			"extension": "",
+			"name": "",
+			"postdelay": null,
+			"predelay": null,
+			"type": "Mobile",
+			"capabilities": [
+				"sms",
+				"phone",
+				"push"
+			],
+			"platform": "Apple iOS",
+			"activated": false,
+			"sms_passcodes_sent": false
+		}],
+		"realname": "Joe Smith",
+		"status": "active",
+		"tokens": [{
+			"serial": "0",
+			"token_id": "DHIZ34ALBA2445ND4AI2",
+			"type": "d1"
+		}],
+		"user_id": "DU3RP9I2WOC59VZX672N",
+		"username": "jsmith"
+	}
+}`
+
+func TestModifyUser(t *testing.T) {
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, modifyUserResponse)
+		}),
+	)
+	defer ts.Close()
+
+	duo := buildAdminClient(ts.URL, nil)
+
+	userToModify := User{
+		UserID: "DU3RP9I2WOC59VZX672N",
+		Email:  "jsmith-new@example.com",
+	}
+
+	result, err := duo.ModifyUser(userToModify.UserID, userToModify)
+	if err != nil {
+		t.Errorf("Unexpected error from ModifyUser call %v", err.Error())
+	}
+	if result.Stat != "OK" {
+		t.Errorf("Expected OK, but got %s", result.Stat)
+	}
+	if result.Response.UserID != userToModify.UserID {
+		t.Errorf("Expected UserID to be %s, but got %s", userToModify.UserID, result.Response.UserID)
+	}
+	if result.Response.Email != userToModify.Email {
+		t.Errorf("Expected Email to be %s, but got %s", userToModify.Email, result.Response.Email)
+	}
+}
+
+const deleteUserResponse = `{
+	"stat": "OK",
+	"response": ""
+}`
+
+func TestDeleteUser(t *testing.T) {
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, deleteUserResponse)
+		}),
+	)
+	defer ts.Close()
+
+	duo := buildAdminClient(ts.URL, nil)
+
+	result, err := duo.DeleteUser("DU3RP9I2WOC59VZX672N")
+	if err != nil {
+		t.Errorf("Unexpected error from DeleteUser call %v", err.Error())
+	}
+	if result.Stat != "OK" {
+		t.Errorf("Expected OK, but got %s", result.Stat)
+	}
+}
+
 const getUsersPage1Response = `{
 	"stat": "OK",
 	"metadata": {
@@ -567,6 +723,54 @@ func TestGetUserGroupsPageArgs(t *testing.T) {
 	}
 	if request_query["offset"][0] != "1" {
 		t.Errorf("Expected to see an offset of 0 in request, bug got %s", request_query["offset"])
+	}
+}
+
+const associateGroupWithUserResponse = `{
+	"stat": "OK",
+	"response": ""
+}`
+
+func TestAssociateGroupWithUser(t *testing.T) {
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, associateGroupWithUserResponse)
+		}),
+	)
+	defer ts.Close()
+
+	duo := buildAdminClient(ts.URL, nil)
+
+	result, err := duo.AssociateGroupWithUser("DU3RP9I2WOC59VZX672N", "DGXXXXXXXXXXXXXXXXXX")
+	if err != nil {
+		t.Errorf("Unexpected error from AssociateGroupWithUser call %v", err.Error())
+	}
+	if result.Stat != "OK" {
+		t.Errorf("Expected OK, but got %s", result.Stat)
+	}
+}
+
+const disassociateGroupFromUserResponse = `{
+	"stat": "OK",
+	"response": ""
+}`
+
+func TestDisassociateGroupFromUser(t *testing.T) {
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, associateGroupWithUserResponse)
+		}),
+	)
+	defer ts.Close()
+
+	duo := buildAdminClient(ts.URL, nil)
+
+	result, err := duo.DisassociateGroupFromUser("DU3RP9I2WOC59VZX672N", "DGXXXXXXXXXXXXXXXXXX")
+	if err != nil {
+		t.Errorf("Unexpected error from DisassociateGroupFromUser call %v", err.Error())
+	}
+	if result.Stat != "OK" {
+		t.Errorf("Expected OK, but got %s", result.Stat)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/duosecurity/duo_api_golang
 
-go 1.13
+require github.com/google/go-querystring v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/duosecurity/duo_api_golang
 
-require github.com/google/go-querystring v1.0.0
+go 1.15

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
-github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=


### PR DESCRIPTION
Largely based on the work done in #12 with the requested changes to match the existing pattern to pass params into CreateUser and ModifyUser.

Added a reflect based parsing of User to url.Value based params. This removes the "github.com/google/go-querystring/query" dependency that #12 added, and provides more or less the same convenience functionality for the developer.