### PR TITLE
Closing response body before retrying to release network resources

### DIFF
--- a/duoapi.go
+++ b/duoapi.go
@@ -323,6 +323,8 @@ func (duoapi *DuoApi) makeRetryableHttpCall(
 			return resp, body, err
 		}
 
+		resp.Body.Close()
+
 		duoapi.sleepSvc.Sleep(time.Millisecond * time.Duration(backoffMs))
 		backoffMs *= backoffFactor
 	}


### PR DESCRIPTION
The retryable HTTP call is [not closing the response body](https://github.com/duosecurity/duo_api_golang/blob/master/duoapi.go#L314-L327) and doing the next iteration in case of the 429 response code. Due to this mechanism eventually, all the persistent TCP connections are getting consumed and unable to make any further calls. As per the official [doc](https://pkg.go.dev/net/http#Client.Do), the user is responsible to close the body.