### PR TITLE
Add function to set a custom http client to the duo api

### DIFF
--- a/duoapi.go
+++ b/duoapi.go
@@ -214,6 +214,13 @@ type StatResult struct {
 	Message_Detail *string
 }
 
+// SetCustomHTTPClient allows one to set a completely custom http client that
+// will be used to make network calls to the duo api
+func (duoapi *DuoApi) SetCustomHTTPClient(c *http.Client) {
+	duoapi.apiClient = c
+	duoapi.authClient = c
+}
+
 // Make an unsigned Duo Rest API call.  See Duo's online documentation
 // for the available REST API's.
 // method is POST or GET


### PR DESCRIPTION
This function is useful for us because it will allow us to set a custom http client that we use on our server to ensure no calls can be made to any insecure locations.

