### PR TITLE
Handle StatResult.Code is empty string

### DIFF
--- a/authapi/authapi.go
+++ b/authapi/authapi.go
@@ -48,6 +48,7 @@ func (api *AuthApi) Ping() (*PingResult, error) {
 	if err = json.Unmarshal(body, ret); err != nil {
 		return nil, err
 	}
+	ret.SyncCode()
 	return ret, nil
 }
 
@@ -72,6 +73,7 @@ func (api *AuthApi) Check() (*CheckResult, error) {
 	if err = json.Unmarshal(body, ret); err != nil {
 		return nil, err
 	}
+	ret.SyncCode()
 	return ret, nil
 }
 
@@ -98,6 +100,7 @@ func (api *AuthApi) Logo() (*LogoResult, error) {
 	if err = json.Unmarshal(body, ret); err != nil {
 		return nil, err
 	}
+	ret.SyncCode()
 	return ret, nil
 }
 
@@ -145,6 +148,7 @@ func (api *AuthApi) Enroll(options ...func(*url.Values)) (*EnrollResult, error) 
 	if err = json.Unmarshal(body, ret); err != nil {
 		return nil, err
 	}
+	ret.SyncCode()
 	return ret, nil
 }
 
@@ -174,6 +178,7 @@ func (api *AuthApi) EnrollStatus(userid string,
 	if err = json.Unmarshal(body, ret); err != nil {
 		return nil, err
 	}
+	ret.SyncCode()
 	return ret, nil
 }
 
@@ -239,6 +244,7 @@ func (api *AuthApi) Preauth(options ...func(*url.Values)) (*PreauthResult, error
 	if err = json.Unmarshal(body, ret); err != nil {
 		return nil, err
 	}
+	ret.SyncCode()
 	return ret, nil
 }
 
@@ -348,6 +354,7 @@ func (api *AuthApi) Auth(factor string, options ...func(*url.Values)) (*AuthResu
 	if err = json.Unmarshal(body, ret); err != nil {
 		return nil, err
 	}
+	ret.SyncCode()
 	return ret, nil
 }
 
@@ -377,5 +384,6 @@ func (api *AuthApi) AuthStatus(txid string) (*AuthStatusResult, error) {
 	if err = json.Unmarshal(body, ret); err != nil {
 		return nil, err
 	}
+	ret.SyncCode()
 	return ret, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR handles the case when `StatResult.Code` is an empty string. The following changes are introduced:
- An additional `Ncode` field is added to `StatResult`, corresponding to `code` in JSON.
- Empty string `Code` is handled in a custom `json.Unmarshal` method for `Ncode`. In case of empty string, `0` is assigned to `Code`.
- A function to assign value of `Ncode` to `Code` is added.

## Motivation and Context
This fixes the issue of Go client not being able to handle codeless errors.

## How Has This Been Tested?
`TestEmptyResponseCode` was added to test the behaviour with empty string `Code`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
