### PR TITLE
Fix user.URLValues() to skip pointer values that are empty

### DIFF
--- a/admin/admin.go
+++ b/admin/admin.go
@@ -62,7 +62,7 @@ type User struct {
 }
 
 // URLValues transforms a User into url.Values using the 'url' struct tag to
-// define the key of the map. Fields are skiped if the value is empty.
+// define the key of the map. Fields are skipped if the value is empty.
 func (u *User) URLValues() url.Values {
 	params := url.Values{}
 
@@ -75,17 +75,20 @@ func (u *User) URLValues() url.Values {
 		if tag == "" {
 			continue
 		}
-		// Skip fields have a zero value.
-		if v.Field(i).Interface() == reflect.Zero(v.Field(i).Type()).Interface() {
+
+		f := v.Field(i)
+
+		// Dereference Pointers
+		if f.Kind() == reflect.Ptr && !f.IsNil() {
+			f = f.Elem()
+		}
+
+		// Skip fields that have a zero value.
+		if f.Interface() == reflect.Zero(f.Type()).Interface() {
 			continue
 		}
-		var val string
-		if t.Field(i).Type.Kind() == reflect.Ptr {
-			val = fmt.Sprintf("%v", v.Field(i).Elem())
-		} else {
-			val = fmt.Sprintf("%v", v.Field(i))
-		}
-		params[tag] = []string{val}
+
+		params[tag] = []string{fmt.Sprintf("%v", f)}
 	}
 	return params
 }

--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -159,6 +159,7 @@ func TestUser_URLValues(t *testing.T) {
 	}
 
 	exAlias := "smith"
+	emptyFirstName := ""
 
 	tests := []struct {
 		name   string
@@ -199,6 +200,18 @@ func TestUser_URLValues(t *testing.T) {
 				Groups:   []Group{{Name: "group1"}},
 				Phones:   []Phone{{Name: "phone1"}},
 				Tokens:   []Token{{TokenID: "token1"}},
+			},
+			want: url.Values(map[string][]string{
+				"username": {"jsmith"}},
+			),
+		},
+		{
+			name: "Empty values skipped",
+			fields: fields{
+				Username:  "jsmith",
+				FirstName: &emptyFirstName,
+				LastName:  nil,
+				Notes:     "",
 			},
 			want: url.Values(map[string][]string{
 				"username": {"jsmith"}},


### PR DESCRIPTION
## Description

Fix `user.URLValues()` to also skip pointer values that are zero values. Previously `user.URLValues()` would return a `[]string{""}` for the pointer struct attributes if empty.

## Motivation and Context
When the output of `URLValues()` was used as input to ModifyUser, for example, the attributes incorrectly set to `[]string{""}` would result in the user having those values set to `""` via the Admin API. Resulting in unexpected attribute changes.

## How Has This Been Tested?
Added additional test case that includes the possible types of zero values, as well as a live test against a Duo instance's Admin API.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
