### PR TITLE
Fix json marshalling of StatResult.Ncode field

### DIFF
--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -2385,3 +2385,39 @@ func TestGetBypassCodes(t *testing.T) {
 		t.Errorf("Expected 10 codes, but got %d", len(result.Response))
 	}
 }
+
+const getErrorGetUsersResponse = `{
+	"stat": "FAIL",
+	"code": 500,
+	"message": "Internal Server Error",
+	"message_detail": "The server encountered an internal error and was unable to complete your request"
+}`
+
+func TestErrorGetUsers(t *testing.T) {
+	ts := httptest.NewTLSServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintln(w, getErrorGetUsersResponse)
+		}),
+	)
+	defer ts.Close()
+
+	duo := buildAdminClient(ts.URL, nil)
+
+	result, err := duo.GetUsers()
+	if err != nil {
+		t.Errorf("Unexpected error from GetUsers call %v", err.Error())
+	}
+	if result.Stat != "FAIL" {
+		t.Errorf("Expected FAIL, but got %s", result.Stat)
+	}
+	result.SyncCode()
+	if *result.Code != 500 {
+		t.Errorf("Expected 500, but got %d", *result.Code)
+	}
+	if *result.Message != "Internal Server Error" {
+		t.Errorf("Expected Internal Server Error, but got %s", *result.Message)
+	}
+	if *result.Message_Detail != "The server encountered an internal error and was unable to complete your request" {
+		t.Errorf("Expected Message_Detail to be The server encountered an internal error and was unable to complete your request, but got %s", *result.Message_Detail)
+	}
+}

--- a/duoapi.go
+++ b/duoapi.go
@@ -292,6 +292,13 @@ func (n *NullableInt32) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+func (n NullableInt32) MarshalJSON() ([]byte, error) {
+	if n.value == nil {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(*n.value)
+}
+
 func (s *StatResult) SyncCode() {
 	s.Code = s.Ncode.value
 }


### PR DESCRIPTION
Code fix for correctly marshalling the StatResult's Ncode field in json format.

## Description
Currently, the `Ncode` field of `StatResult` is marshalled as an empty object in json form. Needed a MarshalJSON func to correctly render the value in json.

## Motivation and Context
Correctly maintains the backward compatibitlity with previous versions.

## How Has This Been Tested?
Added tests for error response in `admin/admin_test.go`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
