### PR TITLE
Add an option to disable CA certificate pinning

### DIFF
--- a/duo_test.go
+++ b/duo_test.go
@@ -203,6 +203,36 @@ func TestNewDuo(t *testing.T) {
 	}
 }
 
+func TestNewDuoDefaultHasCAPinning(t *testing.T) {
+	duo := NewDuoApi("ABC", "123", "api-XXXXXXX.duosecurity.com", "go-client")
+	httpClient := duo.apiClient.(*http.Client)
+	transport := httpClient.Transport.(*http.Transport)
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Fatal("Default Duo API client should have pinned CA certificates")
+	}
+}
+
+func TestSetCAPinningEnabled(t *testing.T) {
+	duo := NewDuoApi("ABC", "123", "api-XXXXXXX.duosecurity.com", "go-client", SetCAPinning(true))
+	httpClient := duo.apiClient.(*http.Client)
+	transport := httpClient.Transport.(*http.Transport)
+	if transport.TLSClientConfig.RootCAs == nil {
+		t.Fatal("Duo API client with CA pinning enabled should have pinned CA certificates")
+	}
+}
+
+func TestSetCAPinningDisabled(t *testing.T) {
+	duo := NewDuoApi("ABC", "123", "api-XXXXXXX.duosecurity.com", "go-client", SetCAPinning(false))
+	httpClient := duo.apiClient.(*http.Client)
+	transport := httpClient.Transport.(*http.Transport)
+	if transport.TLSClientConfig.RootCAs != nil {
+		t.Fatal("Duo API client with CA pinning disabled should use system trust store (nil RootCAs)")
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("Disabling CA pinning should not disable TLS verification")
+	}
+}
+
 func TestSetTransport(t *testing.T) {
 	transportOpt := func(tr *http.Transport) {
 		tr.MaxResponseHeaderBytes = 12345

--- a/duoapi.go
+++ b/duoapi.go
@@ -147,10 +147,11 @@ func (svc timeSleepService) Sleep(duration time.Duration) {
 }
 
 type apiOptions struct {
-	timeout   time.Duration
-	insecure  bool
-	proxy     func(*http.Request) (*url.URL, error)
-	transport func(*http.Transport)
+	timeout      time.Duration
+	insecure     bool
+	proxy        func(*http.Request) (*url.URL, error)
+	transport    func(*http.Transport)
+	caPinning    bool
 }
 
 // Optional parameter for NewDuoApi, used to configure timeouts on API calls.
@@ -183,6 +184,16 @@ func SetTransport(transport func(*http.Transport)) func(*apiOptions) {
 	}
 }
 
+// SetCAPinning controls whether Duo's CA certificate pinning is enforced.
+// When set to false, the client uses the system's default certificate trust store
+// instead of the pinned Duo CA certificates, while keeping TLS verification active.
+// Default is true (CA pinning enabled).
+func SetCAPinning(enabled bool) func(*apiOptions) {
+	return func(opts *apiOptions) {
+		opts.caPinning = enabled
+	}
+}
+
 // Build an return a DuoApi struct.
 // ikey is your Duo integration key
 // skey is your Duo integration secret key
@@ -199,21 +210,24 @@ func NewDuoApi(ikey string,
 	host string,
 	userAgent string,
 	options ...func(*apiOptions)) *DuoApi {
-	opts := apiOptions{proxy: http.ProxyFromEnvironment}
+	opts := apiOptions{proxy: http.ProxyFromEnvironment, caPinning: true}
 	for _, o := range options {
 		o(&opts)
 	}
 
-	// Certificate pinning
-	certPool := x509.NewCertPool()
-	certPool.AppendCertsFromPEM([]byte(duoPinnedCert))
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: opts.insecure,
+	}
+
+	if opts.caPinning {
+		certPool := x509.NewCertPool()
+		certPool.AppendCertsFromPEM([]byte(duoPinnedCert))
+		tlsConfig.RootCAs = certPool
+	}
 
 	tr := &http.Transport{
-		Proxy: opts.proxy,
-		TLSClientConfig: &tls.Config{
-			RootCAs:            certPool,
-			InsecureSkipVerify: opts.insecure,
-		},
+		Proxy:           opts.proxy,
+		TLSClientConfig: tlsConfig,
 	}
 	if opts.transport != nil {
 		opts.transport(tr)

--- a/duoapi.go
+++ b/duoapi.go
@@ -147,11 +147,11 @@ func (svc timeSleepService) Sleep(duration time.Duration) {
 }
 
 type apiOptions struct {
-	timeout      time.Duration
-	insecure     bool
-	proxy        func(*http.Request) (*url.URL, error)
-	transport    func(*http.Transport)
-	caPinning    bool
+	timeout   time.Duration
+	insecure  bool
+	proxy     func(*http.Request) (*url.URL, error)
+	transport func(*http.Transport)
+	caPinning bool
 }
 
 // Optional parameter for NewDuoApi, used to configure timeouts on API calls.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - Adds `SetCAPinning(enabled bool)` functional option to `NewDuoApi` that controls whether Duo's CA certificate pinning is enforced
  - When disabled (`SetCAPinning(false)`), the client uses the OS default certificate trust store instead of the pinned Duo CA certificates, while keeping full TLS verification active
  - Default behavior is unchanged — CA pinning remains enabled unless explicitly opted out
  - Refactored `NewDuoApi` to conditionally build the `RootCAs` cert pool based on the `caPinning` option, rather than always constructing and assigning it

## How Has This Been Tested?
  - `TestNewDuoDefaultHasCAPinning` — verifies that the default client (no options) still has a non-nil `RootCAs` (pinned certificates enforced)
  - `TestSetCAPinningEnabled` — verifies that explicitly passing `SetCAPinning(true)` results in pinned certificates
  - `TestSetCAPinningDisabled` — verifies that `SetCAPinning(false)` results in nil `RootCAs` (system trust store) and confirms `InsecureSkipVerify` remains `false` (TLS verification is still active)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
