### PR TITLE
Add CA bundle version and pinning status to the user agent string

### DIFF
--- a/duo_test.go
+++ b/duo_test.go
@@ -233,6 +233,29 @@ func TestSetCAPinningDisabled(t *testing.T) {
 	}
 }
 
+func TestUserAgentIncludesCABundleAndPinningEnabled(t *testing.T) {
+	duo := NewDuoApi("ABC", "123", "api-XXXXXXX.duosecurity.com", "go-client")
+	if !strings.Contains(duo.userAgent, "ca_bundle/"+caBundleVersion) {
+		t.Fatalf("User agent should include the CA bundle version, got: %q", duo.userAgent)
+	}
+	if !strings.Contains(duo.userAgent, "(ca_pinning=enabled)") {
+		t.Fatalf("User agent should report (ca_pinning=enabled) by default, got: %q", duo.userAgent)
+	}
+	if strings.Contains(duo.userAgent, "(ca_pinning=disabled)") {
+		t.Fatalf("User agent should not report (ca_pinning=disabled) when pinning is enabled, got: %q", duo.userAgent)
+	}
+}
+
+func TestUserAgentReportsPinningDisabled(t *testing.T) {
+	duo := NewDuoApi("ABC", "123", "api-XXXXXXX.duosecurity.com", "go-client", SetCAPinning(false))
+	if !strings.Contains(duo.userAgent, "ca_bundle/"+caBundleVersion) {
+		t.Fatalf("User agent should include the CA bundle version, got: %q", duo.userAgent)
+	}
+	if !strings.Contains(duo.userAgent, "(ca_pinning=disabled)") {
+		t.Fatalf("User agent should report (ca_pinning=disabled) when pinning is disabled, got: %q", duo.userAgent)
+	}
+}
+
 func TestSetTransport(t *testing.T) {
 	transportOpt := func(tr *http.Transport) {
 		tr.MaxResponseHeaderBytes = 12345

--- a/duoapi.go
+++ b/duoapi.go
@@ -22,6 +22,8 @@ import (
 const (
 	version           = "0.2.0"
 	defaultUserAgent  = "duo_api_golang/" + version
+	caBundleVersion   = "1.0"
+	caBundleUserAgent = "ca_bundle/" + caBundleVersion
 	initialBackoffMS  = 1000
 	maxBackoffMS      = 32000
 	backoffFactor     = 2
@@ -194,6 +196,15 @@ func SetCAPinning(enabled bool) func(*apiOptions) {
 	}
 }
 
+// caPinningUserAgent returns the user agent fragment describing the current
+// CA pinning state, e.g. "(ca_pinning=enabled)" or "(ca_pinning=disabled)".
+func caPinningUserAgent(enabled bool) string {
+	if enabled {
+		return "(ca_pinning=enabled)"
+	}
+	return "(ca_pinning=disabled)"
+}
+
 // Build an return a DuoApi struct.
 // ikey is your Duo integration key
 // skey is your Duo integration secret key
@@ -236,7 +247,7 @@ func NewDuoApi(ikey string,
 	if userAgent != "" {
 		userAgent += " "
 	}
-	userAgent += defaultUserAgent
+	userAgent += defaultUserAgent + " " + caBundleUserAgent + " " + caPinningUserAgent(opts.caPinning)
 
 	return &DuoApi{
 		ikey:      ikey,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
  - Added `caBundleVersion` ("1.0") and `caBundleUserAgent` ("ca_bundle/1.0") constants in `duoapi.go`.
  - Added `caPinningUserAgent(enabled bool)` helper returning `(ca_pinning=enabled)` or `(ca_pinning=disabled)`.
  - Updated `NewDuoApi` to append `ca_bundle/1.0` and the pinning status to the user agent, deriving the status from the same `opts.caPinning` flag that configures TLS — so the reported value always matches the client's actual pinning state.

## How Has This Been Tested?
  - `TestUserAgentIncludesCABundleAndPinningEnabled` — verifies the default client includes `ca_bundle/1.0` and reports `(ca_pinning=enabled)`, and does not report disabled.
  - `TestUserAgentReportsPinningDisabled` — verifies that with `SetCAPinning(false)` the user agent includes `ca_bundle/1.0` and reports `(ca_pinning=disabled)`.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
